### PR TITLE
Environment "k-out-of-n" update

### DIFF
--- a/pymarl/config/envs/struct.yaml
+++ b/pymarl/config/envs/struct.yaml
@@ -4,7 +4,7 @@ env_args:
   components: 2
   state_config: obs
   discount_reward: 0.95
-  k_comp: 1
+  k_comp: None
 
 learner_log_interval: 10000
 log_interval: 10000

--- a/pymarl/config/envs/struct.yaml
+++ b/pymarl/config/envs/struct.yaml
@@ -3,6 +3,8 @@ env: struct
 env_args:
   components: 2
   state_config: obs
+  discount_reward: 0.95
+  k_comp: 1
 
 learner_log_interval: 10000
 log_interval: 10000

--- a/pymarl/config/envs/struct_sarl.yaml
+++ b/pymarl/config/envs/struct_sarl.yaml
@@ -3,6 +3,8 @@ env: struct_sarl
 env_args:
   components: 2
   state_config: obs
+  discount_reward: 0.95
+  k_comp: None
 
 learner_log_interval: 10000
 log_interval: 10000

--- a/qvmix.sbatch
+++ b/qvmix.sbatch
@@ -14,4 +14,4 @@
 conda activate qVmix
 # Run your Python script
 cd /home/pleroy/struct_marl
-./run.sh $1 $2
+./run.sh $1 $2 $3

--- a/run.sh
+++ b/run.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 set -x
 #source env/bin/activate
-python main.py --config=$1 --env-config=struct with env_args.components=$2 env_args.state_config=$3 use_tensorboard=True name=$1_comp_$2_state_$3
+python main.py --config=$1 --env-config=struct with env_args.components=$2 env_args.k_comp=$3 use_tensorboard=True name=$1_comp_$2_$3_run$4
 #deactivate

--- a/struct_env/pymarl_ma_struct.py
+++ b/struct_env/pymarl_ma_struct.py
@@ -7,6 +7,7 @@ class PymarlMAStruct(MultiAgentEnv):
     def __init__(self,
                  components=2,  # Number of structure
                  discount_reward=1.,
+                 k_comp=1,
                  # float [0,1] importance of short-time reward vs long-time reward
                  state_config="obs",  # State config ["obs", "belief"]
                  seed=None):
@@ -14,7 +15,8 @@ class PymarlMAStruct(MultiAgentEnv):
         self.state_config = state_config
         self._seed = seed
         self.config = {"components": components,
-                       "discount_reward": discount_reward}
+                       "discount_reward": discount_reward,
+                       "k_comp": k_comp}
         self.struct_env = Struct(self.config)
         self.n_agents = self.struct_env.ncomp
         self.episode_limit = self.struct_env.ep_length

--- a/struct_env/pymarl_ma_struct.py
+++ b/struct_env/pymarl_ma_struct.py
@@ -7,7 +7,7 @@ class PymarlMAStruct(MultiAgentEnv):
     def __init__(self,
                  components=2,  # Number of structure
                  discount_reward=1.,
-                 k_comp=1,
+                 k_comp=None,
                  # float [0,1] importance of short-time reward vs long-time reward
                  state_config="obs",  # State config ["obs", "belief"]
                  seed=None):

--- a/struct_env/pymarl_ma_struct.py
+++ b/struct_env/pymarl_ma_struct.py
@@ -6,9 +6,11 @@ class PymarlMAStruct(MultiAgentEnv):
 
     def __init__(self,
                  components=2,  # Number of structure
-                 discount_reward=1.,
-                 k_comp=None,
-                 # float [0,1] importance of short-time reward vs long-time reward
+                 discount_reward=1.,  # float [0,1] importance of
+                                        # short-time reward
+                                        # vs long-time reward
+                 k_comp=None, # Number of structure
+                                # required (k_comp out of components)
                  state_config="obs",  # State config ["obs", "belief"]
                  seed=None):
         self.discount_reward = discount_reward

--- a/struct_env/pymarl_sa_struct.py
+++ b/struct_env/pymarl_sa_struct.py
@@ -11,13 +11,16 @@ class PymarlSAStruct(MultiAgentEnv):
                  components=2,  # Number of structure
                  discount_reward=1.,
                  # float [0,1] importance of short-time reward vs long-time reward
-                 state_config="obs",  # State config ["obs", "belief"]
+                 k_comp=None,  # Number of structure
+                 # required (k_comp out of components)
+                    state_config="obs",  # State config ["obs", "belief"]
                  seed=None):
         self.discount_reward = discount_reward
         self.state_config = state_config
         self._seed = seed
         self.config = {"components": components,
-                       "discount_reward": discount_reward}
+                       "discount_reward": discount_reward,
+                       "k_comp": k_comp}
         self.struct_env = Struct(self.config)
         self.n_agents = 1
         self.n_comp = self.struct_env.ncomp

--- a/struct_env/struct_env.py
+++ b/struct_env/struct_env.py
@@ -20,7 +20,7 @@ class Struct:
         self.obs_total_single = 30 * self.ncomp + 1
 
         ### Loading the underlying POMDP model ###
-        drmodel = np.load('../pomdp_models/Dr3031C10.npz')
+        drmodel = np.load('pomdp_models/Dr3031C10.npz')
 
         # (10 components, 30 crack states)
         self.belief0 = np.zeros((self.ncomp, self.nstcomp))

--- a/struct_env/struct_env.py
+++ b/struct_env/struct_env.py
@@ -5,10 +5,10 @@ class Struct:
 
     def __init__(self, config=None):
         if config is None:
-            config = {"components": 2, "discount_reward": 1, "k_comp": 1}
+            config = {"components": 2, "discount_reward": 1, "k_comp": None}
         self.ncomp = config["components"]
         self.discount_reward = config["discount_reward"]
-        self.k_comp = config["k_comp"]
+        self.k_comp = self.ncomp-1 if config["k_comp"] is None else config["k_comp"]
         self.time = 0
         self.ep_length = 30
         self.nstcomp = 30  # What is this?


### PR DESCRIPTION
Previously, the environment was limited to 10 components.
Now:
- A number of components 'n' can be easily specified (even more than 10 components).
- The 'k' can also be specified from the input file.
Now, SARL environment might need a small readjustment. However, all the conducted tests up to the moment are valid.