### PR TITLE
Campaign setting implemented

### DIFF
--- a/pymarl/config/envs/struct.yaml
+++ b/pymarl/config/envs/struct.yaml
@@ -6,7 +6,7 @@ env_args:
   obs_config: so
   discount_reward: 0.95
   env_type: uncorrelated
-  campaign_cost=False
+  campaign_cost: False
 
 learner_log_interval: 10000
 log_interval: 10000

--- a/pymarl/config/envs/struct.yaml
+++ b/pymarl/config/envs/struct.yaml
@@ -6,6 +6,7 @@ env_args:
   obs_config: so
   discount_reward: 0.95
   env_type: uncorrelated
+  campaign_cost=False
 
 learner_log_interval: 10000
 log_interval: 10000

--- a/pymarl/config/envs/struct_corr.yaml
+++ b/pymarl/config/envs/struct_corr.yaml
@@ -6,7 +6,7 @@ env_args:
   obs_config: so
   discount_reward: 0.95
   env_type: correlated
-  campaign_cost=False
+  campaign_cost: False
 
 learner_log_interval: 10000
 log_interval: 10000

--- a/pymarl/config/envs/struct_corr.yaml
+++ b/pymarl/config/envs/struct_corr.yaml
@@ -6,6 +6,7 @@ env_args:
   obs_config: so
   discount_reward: 0.95
   env_type: correlated
+  campaign_cost=False
 
 learner_log_interval: 10000
 log_interval: 10000

--- a/pymarl/config/envs/struct_sarl.yaml
+++ b/pymarl/config/envs/struct_sarl.yaml
@@ -6,7 +6,7 @@ env_args:
   discount_reward: 0.95
   k_comp: None
   env_type: uncorrelated
-  campaign_cost=False
+  campaign_cost: False
 
 learner_log_interval: 10000
 log_interval: 10000

--- a/pymarl/config/envs/struct_sarl.yaml
+++ b/pymarl/config/envs/struct_sarl.yaml
@@ -5,6 +5,8 @@ env_args:
   state_config: obs
   discount_reward: 0.95
   k_comp: None
+  env_type: uncorrelated
+  campaign_cost=False
 
 learner_log_interval: 10000
 log_interval: 10000

--- a/struct_env/pymarl_ma_struct.py
+++ b/struct_env/pymarl_ma_struct.py
@@ -25,6 +25,8 @@ class PymarlMAStruct(MultiAgentEnv):
                  # "ao_ad"], # all_obs + all drate
                  env_type="uncorrelated",
                  # Env type = ["uncorrelated", "correlated"]
+                 campaign_cost=False
+                 # campaign_cost = [False, True]
                  seed=None):
 
         assert obs_config in ["so",
@@ -39,6 +41,8 @@ class PymarlMAStruct(MultiAgentEnv):
             "Error in k_comp"
         assert env_type in ["uncorrelated", "correlated"], \
             "Error in env_type"
+        assert campaign_cost in [True, False], \
+            "Error in campaign_cost"
 
         self.discount_reward = discount_reward
         self.state_config = state_config
@@ -47,7 +51,8 @@ class PymarlMAStruct(MultiAgentEnv):
         self.config = {"components": components,
                        "discount_reward": discount_reward,
                        "k_comp": k_comp,
-                       "env_type": env_type}
+                       "env_type": env_type,
+                       "campaign_cost": campaign_cost}
         self.struct_env = Struct(self.config)
         self.n_agents = self.struct_env.ncomp
         self.n_comp = self.struct_env.ncomp

--- a/struct_env/pymarl_ma_struct.py
+++ b/struct_env/pymarl_ma_struct.py
@@ -25,7 +25,7 @@ class PymarlMAStruct(MultiAgentEnv):
                  # "ao_ad"], # all_obs + all drate
                  env_type="uncorrelated",
                  # Env type = ["uncorrelated", "correlated"]
-                 campaign_cost=False
+                 campaign_cost=False,
                  # campaign_cost = [False, True]
                  seed=None):
 

--- a/struct_env/pymarl_sa_struct.py
+++ b/struct_env/pymarl_sa_struct.py
@@ -22,7 +22,7 @@ class PymarlSAStruct(MultiAgentEnv):
                  # In SARL, there is not "obs_config"
                  env_type="uncorrelated",
                  # Env type = ["uncorrelated", "correlated"]
-                 campaign_cost=False
+                 campaign_cost=False,
                  # campaign_cost = [False, True]
                  seed=None):
 

--- a/struct_env/pymarl_sa_struct.py
+++ b/struct_env/pymarl_sa_struct.py
@@ -22,6 +22,8 @@ class PymarlSAStruct(MultiAgentEnv):
                  # In SARL, there is not "obs_config"
                  env_type="uncorrelated",
                  # Env type = ["uncorrelated", "correlated"]
+                 campaign_cost=False
+                 # campaign_cost = [False, True]
                  seed=None):
 
         assert state_config in ["obs", "drate", "all"], \
@@ -30,6 +32,8 @@ class PymarlSAStruct(MultiAgentEnv):
             "Error in k_comp"
         assert env_type in ["uncorrelated", "correlated"], \
             "Error in env_type"
+        assert campaign_cost in [True, False], \
+            "Error in campaign_cost"
 
         self.discount_reward = discount_reward
         self.state_config = state_config
@@ -37,7 +41,8 @@ class PymarlSAStruct(MultiAgentEnv):
         self.config = {"components": components,
                        "discount_reward": discount_reward,
                        "k_comp": k_comp,
-                       "env_type": env_type}
+                       "env_type": env_type,
+                       "campaign_cost": campaign_cost}
         self.struct_env = Struct(self.config)
         self.n_agents = 1
         self.n_comp = self.struct_env.ncomp


### PR DESCRIPTION
I have now implemented the "campaign setting", where a campaign cost is added on top of individual inspections/repairs if at least one intervention is executed. 
We can combine this option with either "uncorrelated" or "correlated" settings. :)
And I think with this, we finalize the implementation of this environment.
Let me know if you agree with the additions/changes.

P.S. I have also modified 'self.beliefsc = bc_prime' (line 149). I had problems during the test of uncorrelated environments.